### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ public/dist/
 config/env/local.js
 config/env/local-*.js
 
+# Log file
+# ======================
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# Build:
+# docker build -t meanjs/mean .
+#
+# Run:
+# docker run -it meanjs/mean
+#
+# Compose:
+# docker-compose up -d
+
+FROM ubuntu:latest
+MAINTAINER MEAN.JS
+
+# 80 = HTTP, 443 = HTTPS, 3000 = MEAN.JS server, 35729 = livereload, 8080 = node-inspector
+EXPOSE 80 443 3000 35729 8080
+
+# Set development environment as default
+ENV NODE_ENV development
+
+# Install Utilities
+RUN apt-get update -q  \
+ && apt-get install -yqq \
+ curl \
+ git \
+ ssh \
+ gcc \
+ make \
+ build-essential \
+ libkrb5-dev \
+ sudo \
+ apt-utils \
+ python \
+ libpng-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+RUN sudo apt-get install -yq nodejs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install MEAN.JS Prerequisites
+RUN npm install --quiet -g gulp bower yo mocha karma-cli pm2 && npm cache clean
+
+RUN mkdir -p /opt/mean.js/public/lib
+WORKDIR /opt/mean.js
+
+# Copies the local package.json file to the container
+# and utilities docker container cache to not needing to rebuild
+# and install node_modules/ everytime we build the docker, but only
+# when the local package.json file changes.
+# Install npm packages
+COPY package.json /opt/mean.js/package.json
+RUN npm install --quiet && npm cache clean
+
+# Install bower packages
+COPY bower.json /opt/mean.js/bower.json
+COPY .bowerrc /opt/mean.js/.bowerrc
+RUN bower install --quiet --allow-root --config.interactive=false
+
+COPY . /opt/mean.js
+
+# Run MEAN.JS server
+CMD npm install && npm start

--- a/Dockerfile-production
+++ b/Dockerfile-production
@@ -1,0 +1,64 @@
+# Build:
+# docker build -t meanjs/mean -f Dockerfile-production .
+#
+# Run:
+# docker run -it meanjs/mean
+#
+# Compose:
+# docker-compose -f docker-compose-production.yml up -d
+
+FROM ubuntu:latest
+MAINTAINER MEAN.JS
+
+# 80 = HTTP, 443 = HTTPS, 3000 = MEAN.JS server, 35729 = livereload
+EXPOSE 80 443 3000 35729
+
+# Install Utilities
+RUN apt-get update -q  \
+ && apt-get install -yqq \
+ curl \
+ git \
+ ssh \
+ gcc \
+ make \
+ build-essential \
+ libkrb5-dev \
+ sudo \
+ apt-utils \
+ python \
+ libpng-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+RUN sudo apt-get install -yq nodejs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install MEAN.JS Prerequisites
+RUN npm install --quiet -g gulp bower yo mocha karma-cli pm2 && npm cache clean
+
+RUN mkdir -p /opt/mean.js/public/lib
+WORKDIR /opt/mean.js
+
+# Copies the local package.json file to the container
+# and utilities docker container cache to not needing to rebuild
+# and install node_modules/ everytime we build the docker, but only
+# when the local package.json file changes.
+# Install npm packages
+COPY package.json /opt/mean.js/package.json
+RUN NODE_ENV=development npm install --quiet && npm cache clean
+
+# Install bower packages
+COPY bower.json /opt/mean.js/bower.json
+COPY .bowerrc /opt/mean.js/.bowerrc
+RUN bower install --quiet --allow-root --config.interactive=false
+
+# Set development environment as default
+ENV NODE_ENV production
+
+COPY . /opt/mean.js
+
+# Run MEAN.JS server
+CMD ["npm","run-script","start:prod"]

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,0 +1,40 @@
+version: '2'
+services:
+  web:
+    restart: always
+    build:
+     context: .
+     dockerfile: Dockerfile-production
+    container_name: meanjs
+    ports:
+     - "8443:8443"
+    environment:
+     - NODE_ENV=production
+     - DB_1_PORT_27017_TCP_ADDR=db
+    depends_on:
+     - db
+    volumes_from:
+     - web-data
+  web-data:
+    build:
+     context: .
+     dockerfile: Dockerfile-production
+    entrypoint: /bin/true
+    volumes:
+     - /opt/mean.js
+     - /opt/mean.js/node_modules
+     - /opt/mean.js/public
+     - /opt/mean.js/uploads
+  db:
+    image: mongo:3.2
+    restart: always
+    volumes_from:
+      - db-data
+  db-data:
+    image: mongo:3.2
+    volumes:
+      - /data/db
+      - /var/lib/mongodb
+      - /var/log/mongodb
+    entrypoint: /bin/true
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2'
+services:
+  web:
+    restart: always
+    build: .
+    container_name: meanjs
+    ports:
+     - "3000:3000"
+     - "5858:5858"
+     - "8080:8080"
+     - "35729:35729"
+    environment:
+     - NODE_ENV=development
+     - DB_1_PORT_27017_TCP_ADDR=db
+    depends_on:
+     - db
+    volumes_from:
+     - web-data
+  web-data:
+    build: .
+    entrypoint: /bin/true
+    volumes:
+     - ./:/opt/mean.js
+     - /opt/mean.js/node_modules
+     - /opt/mean.js/public
+     - /opt/mean.js/uploads
+  db:
+    image: mongo:3.2
+    restart: always
+    ports:
+     - "27017:27017"
+    volumes_from:
+      - db-data
+  db-data:
+    image: mongo:3.2
+    volumes:
+      - /data/db
+      - /var/lib/mongodb
+      - /var/log/mongodb
+    entrypoint: /bin/true


### PR DESCRIPTION
Add support for a development docker environment and a production docker environment.

Those file are backported from MEAN.js official master branch and have been adapted to work with our own dependencies. This docker environment doesn't include a pythia-core stack.